### PR TITLE
Added potassium tileset to map generation, other misc fixes

### DIFF
--- a/src/Assets.ts
+++ b/src/Assets.ts
@@ -32,6 +32,14 @@ export const WaterTiles: SpriteSheet =
     size: {h: TILE_SIZE, w: TILE_SIZE}
 }
 
+export const PotassiumTiles: SpriteSheet =
+{
+    key: "potassiumtiles",
+    assetLocation: "assets/potassiumtiles.png",
+    numSprites: 256,
+    size: {h: TILE_SIZE, w: TILE_SIZE}
+}
+
 export const GroundTiles: SpriteSheet = 
 {
     key: "groundtiles",

--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -6,7 +6,8 @@ import {
     ResourceTileType,
     Water,
     Potassium,
-    WaterConfigurations
+    WaterConfigurations,
+    PotassiumConfigurations
 } from './Resources';
 
 const perlinMin = -Math.sqrt(2) / 2;
@@ -51,8 +52,10 @@ export default class MapGenerator
         return false;
     }
 
-    private DrawResourceConfiguration(configuration : number[][], gridPosition : Phaser.Math.Vector2, resource : ResourceTileType) 
+    private DrawResourceConfiguration(configuration : number[][], gridPosition : Phaser.Math.Vector2, resource : ResourceTileType, resourceAmount : number) 
     {
+        let count = 0;
+
         for (let r = 0; r < configuration.length; ++r)
         {
             for (let c = 0; c < configuration[r].length; ++c)
@@ -64,13 +67,44 @@ export default class MapGenerator
                     switch (resource)
                     {
                         case ResourceTileType.Water:
-                            resourceTile = Water(0, configuration[r][c]);
+                        {
+                            resourceTile = Water(resourceAmount, configuration[r][c]);
+                            count += 1;
+                            break;
+                        }
+                        case ResourceTileType.Potassium:
+                            resourceTile = Potassium(resourceAmount, configuration[r][c]);
+                            break;
                     }
 
                     this._grid[gridPosition.y + r][gridPosition.x + c] = resourceTile;
                 }
             }
         }
+
+        console.log(count);
+    }
+
+    private DoResourcesOverlap(configuration : number[][], gridPosition : Phaser.Math.Vector2)
+    {
+        // Loop through the configuration 
+        for (let r = 0; r < configuration.length; ++r)
+        {
+            for (let c = 0; c < configuration[r].length; ++c)
+            {
+                // Make sure this tile is in map bounds
+                if (!this.IsOutOfBounds(new Phaser.Math.Vector2(gridPosition.x + c, gridPosition.y + r)))
+                {
+                    // If this tile has a valid tile index and there is already a tile placed here (besides dirt), return true
+                    if (configuration[r][c] >= 0 && this._grid[gridPosition.y + r][gridPosition.x + c] != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     public GenerateMap()
@@ -82,7 +116,7 @@ export default class MapGenerator
 
             var densityMaps : Map<Phaser.Math.Vector2, number> = new Map<Phaser.Math.Vector2, number>();
 
-            for (let chunkRow = 0; chunkRow < Math.floor(this._mapDimensions.y / this._chunkSize); ++chunkRow)
+            for (let chunkRow = 1; chunkRow < Math.floor(this._mapDimensions.y / this._chunkSize); ++chunkRow)
             {
                 for (let chunkColumn = 0; chunkColumn < Math.floor(this._mapDimensions.x / this._chunkSize); ++chunkColumn)
                 {
@@ -94,7 +128,7 @@ export default class MapGenerator
 
             densityMaps.forEach((rarity, chunkPosition) =>
             {
-                var perlinValue = this._noiseGenerator.simplex2(chunkPosition.x / (4), (chunkPosition.y / (4)) * 0.25);
+                var perlinValue = this._noiseGenerator.simplex2(chunkPosition.x / 4, (chunkPosition.y / 4) * 0.25);
 
                 if (perlinValue <= rarity && perlinValue > -rarity)
                 {
@@ -107,10 +141,29 @@ export default class MapGenerator
                         // Pick random tile inside chunk
                         xPos = Math.floor(Math.random() * this._chunkSize) + chunkPosition.x;
                         yPos = Math.floor(Math.random() * this._chunkSize) + chunkPosition.y;
+                        let gridPosition =  new Phaser.Math.Vector2(xPos, yPos);
+                        let configuration : number[][];
 
-                        if (this._grid[yPos][xPos] == null)
+                        switch (Resource)
                         {
-                            this.DrawResourceConfiguration(WaterConfigurations[0], new Phaser.Math.Vector2(xPos, yPos), Resource);
+                            case (ResourceTileType.Potassium):
+                            {
+                                configuration = PotassiumConfigurations[0];
+                                break;
+                            }
+                            case (ResourceTileType.Water):
+                            {
+                                configuration = WaterConfigurations[0];
+                                break;
+                            }
+                        }
+
+                        // If there is no overlap with this resource pattern and another resource
+                        if (!this.DoResourcesOverlap(configuration, gridPosition))
+                        {
+                            var resourceAmount = Math.floor(Math.random() * (ResourceGenData._resourceAmountMax - ResourceGenData._resourceAmountMin) + ResourceGenData._resourceAmountMin);
+
+                            this.DrawResourceConfiguration(configuration, gridPosition, Resource, resourceAmount);
                         }
                         else
                         {
@@ -122,31 +175,6 @@ export default class MapGenerator
                     }
                 }
             })
-
-            // for (let r = 0; r < this._mapDimensions.y; ++r)
-            // {
-            //     this._grid[r] = [];
-            //     for (let c = 0; c < this._mapDimensions.x; ++c)
-            //     {
-            //         var perlinValue = this._noiseGenerator.perlin2(r * Math.random() / 100, c * Math.random() / 100);
-            //         var currentPerlinMin = 0;
-            //         let result : ResourceTile | null = null;
-            //         //console.log(perlinValue);
-
-            //         this._generationData.forEach((value, key) =>
-            //         {
-            //             var perlinMax = currentPerlinMin + value._rarity;
-                        
-            //             if (perlinValue >= currentPerlinMin && perlinValue < perlinMax)
-            //             {
-            //                 result = key;
-            //             }
-            //             currentPerlinMin = perlinMax;
-            //         })
-
-            //         this._grid[r][c] = result;
-            //     }
-            // }
         })
 
         return this._grid;

--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -45,7 +45,6 @@ export default class MapGenerator
         if (position.x < 0 || position.x >= this._mapDimensions.x ||
             position.y < 0 || position.y >= this._mapDimensions.y)
         {
-            console.log(position.x, position.y);
             return true;
         }
 
@@ -54,8 +53,6 @@ export default class MapGenerator
 
     private DrawResourceConfiguration(configuration : number[][], gridPosition : Phaser.Math.Vector2, resource : ResourceTileType, resourceAmount : number) 
     {
-        let count = 0;
-
         for (let r = 0; r < configuration.length; ++r)
         {
             for (let c = 0; c < configuration[r].length; ++c)
@@ -69,7 +66,6 @@ export default class MapGenerator
                         case ResourceTileType.Water:
                         {
                             resourceTile = Water(resourceAmount, configuration[r][c]);
-                            count += 1;
                             break;
                         }
                         case ResourceTileType.Potassium:
@@ -81,8 +77,6 @@ export default class MapGenerator
                 }
             }
         }
-
-        console.log(count);
     }
 
     private DoResourcesOverlap(configuration : number[][], gridPosition : Phaser.Math.Vector2)

--- a/src/Resources.ts
+++ b/src/Resources.ts
@@ -1,7 +1,8 @@
 
 export enum TilemapLayer {
     Root = 'root',
-    Resources = 'resources',
+    Water = 'water',
+    Potassium = 'potassium',
     Dirt = 'dirt'
 }
 
@@ -39,17 +40,17 @@ export const Water = (quantity: number, tileIndex : number): ResourceTile => {
         tilemapIndex: tileIndex,
         resourceQuantity: quantity,
         ratePerSec: 1,
-        tilemapLayer: TilemapLayer.Resources
+        tilemapLayer: TilemapLayer.Water
     }
 }
 
-export const Potassium = (quantity: number): ResourceTile => {
+export const Potassium = (quantity: number, tileIndex : number): ResourceTile => {
     return {
         type: ResourceTileType.Potassium,
-        tilemapIndex: 5,
+        tilemapIndex: tileIndex,
         ratePerSec: 1,
         resourceQuantity: quantity,
-        tilemapLayer: TilemapLayer.Resources
+        tilemapLayer: TilemapLayer.Potassium
     }
 }
 
@@ -60,9 +61,19 @@ export const Potassium = (quantity: number): ResourceTile => {
 //         tilemapLayer: TilemapLayer.Resources
 //     }
 // }
+
+// List of different tile patterns that water can spawn in
 export const WaterConfigurations : number[][][] =
 [
     // basic 4x4
     [[0, 3],
     [12, 15]]
+];
+
+export const PotassiumConfigurations : number[][][] =
+[
+    // basic 4x4
+    [[82, 83, 84],
+     [98, 99, 100],
+     [114, 115, 116]]
 ];

--- a/src/Underground.ts
+++ b/src/Underground.ts
@@ -19,6 +19,7 @@ import {
 import {
     TestTiles,
     WaterTiles,
+    PotassiumTiles,
     GroundTiles
 } from './Assets';
 
@@ -49,12 +50,15 @@ export default class Underground {
 
         const tiles = this._tilemap.addTilesetImage(GroundTiles.key);
         const waterTiles = this._tilemap.addTilesetImage(WaterTiles.key);
+        const potassiumTiles = this._tilemap.addTilesetImage(PotassiumTiles.key);
 
         const layerDirt = this._tilemap.createBlankLayer('dirt', tiles);
-        const layerResources = this._tilemap.createBlankLayer('resources', waterTiles);
+        const layerWater = this._tilemap.createBlankLayer('water', waterTiles);
+        const layerPotassium = this._tilemap.createBlankLayer("potassium", potassiumTiles)
 
         layerDirt.setScale(Constants.TILE_SCALE);
-        layerResources.setScale(Constants.TILE_SCALE);
+        layerWater.setScale(Constants.TILE_SCALE);
+        layerPotassium.setScale(Constants.TILE_SCALE);
 
         layerDirt.fill(
             Dirt.tilemapIndex,

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -11,6 +11,7 @@ import {
   RootSprites,
   TestTiles,
   WaterTiles,
+  PotassiumTiles,
   AbovegroundBGM,
   UndergroundBGM
 } from '../Assets';
@@ -54,6 +55,7 @@ export default class World extends Phaser.Scene {
     AssetLoader.loadSprite(this, RootSprite);
     AssetLoader.loadSpriteSheet(this, TestTiles);
     AssetLoader.loadSpriteSheet(this, WaterTiles);
+    AssetLoader.loadSpriteSheet(this, PotassiumTiles);
     AssetLoader.loadSpriteSheet(this, RootSprites);
     AssetLoader.loadSpriteSheet(this, GroundTiles);
 


### PR DESCRIPTION
- Added potassium tileset and hooked up to generation
- Fixed issue where resources could overlap each other
- Properly set resource amount when spawning resource tiles in the grid